### PR TITLE
set function_graph as default tracer

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -73,3 +73,5 @@ do
 		fi
 	fi
 done
+#enable function_graph as default tracer
+echo function_graph > /sys/kernel/debug/tracing/current_tracer


### PR DESCRIPTION
Change for ftrace should come with function_group tracer by default ( Mantis bug ID -20). 