### PR TITLE
set the user's login shell

### DIFF
--- a/find_disk.sh
+++ b/find_disk.sh
@@ -414,7 +414,7 @@ if [ "$full_intallation" = "yes" ]; then
         ubuntu_username=""
         read -p "Please input the username which you want to create in ubuntu system :" ubuntu_username
         if [ -n "$ubuntu_username" ]; then
-            sudo useradd -m $ubuntu_username
+            sudo useradd -m $ubuntu_username -s /bin/bash
             sudo passwd $ubuntu_username
             cp -a /home/$ubuntu_username rootfs/home/
             sudo chown $ubuntu_username:$ubuntu_username rootfs/home/$ubuntu_username


### PR DESCRIPTION
The useradd command will not set the login shell[1] when  we not use `-s` param.
so we should add a `-s` param to set user's login shell to /bin/bash

[1] man useradd:
    -s, --shell SHELL
        The name of the user's login shell. The default is to leave this field blank,
        which causes the system to select the default login shell specified by the
        SHELL variable in /etc/default/useradd, or an empty string by default.

Signed-off-by: Wang Long <long.wanglong@huawei.com>