### PR TITLE
Add arm32 toolchain for uefi.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -132,22 +132,26 @@ if [ x"$LOCALARCH" = x"x86_64" ]; then
 	echo "# Download/Uncompress toolchain"
 	echo "##############################################################################"
 	mkdir -p toolchain
-	download_toolchain toolchain $TOPDIR/checksum/toolchain/toolchain.sum $ESTUARY_INTERAL_FTP/toolchain
+	download_toolchains toolchain $TOPDIR/checksum/toolchain/toolchain.sum $ESTUARY_INTERAL_FTP/toolchain
 	if [[ $? != 0 ]]; then
-		echo -e "\033[31mError! Download toolchains failed!\033[0m" ; exit 1
+		echo -e "\033[31mError! Download toolchains failed!\033[0m" >&2 ; exit 1
 	fi
-	toolchain=`get_toolchain $TOPDIR/checksum/toolchain/toolchain.sum`
+
+	if ! uncompress_toolchains $TOPDIR/checksum/toolchain/toolchain.sum toolchain; then
+		echo -e "\033[31mError! Uncompress toolchains failed!\033[0m" >&2 ; exit 1
+	fi
+
+	toolchain=`get_toolchain arm $TOPDIR/checksum/toolchain/toolchain.sum`
+	toolchain_dir=`get_compress_file_prefix $toolchain`
+	export PATH=`pwd`/toolchain/$toolchain_dir/bin:$PATH
+
+	toolchain=`get_toolchain aarch64 $TOPDIR/checksum/toolchain/toolchain.sum`
+	toolchain_dir=`get_compress_file_prefix $toolchain`
 	mkdir -p $BUILD_DIR/binary/arm64
 	if ! copy_toolchain $toolchain toolchain $BUILD_DIR/binary/arm64; then
 		echo "Copy $toolchain to $BUILD_DIR/binary/arm64 failed!" >&2 ; exit 1
 	fi
 
-	toolchain_dir=`get_compress_file_prefix $toolchain`
-	if [ ! -d toolchain/$toolchain_dir ]; then
-		if ! uncompress_file toolchain/$toolchain toolchain; then
-			echo -e "\033[31mError! Uncompress toolchain failed!\033[0m" ; exit 1
-		fi
-	fi
 	TOOLCHAIN=$toolchain
 	TOOLCHAIN_DIR=`cd toolchain/$toolchain_dir; pwd`
 	CROSS_COMPILE=`get_cross_compile $LOCALARCH $TOOLCHAIN_DIR`

--- a/checksum/toolchain/toolchain.sum
+++ b/checksum/toolchain/toolchain.sum
@@ -1,1 +1,2 @@
 2ea94e329933f20a4cdf4cdc08e5d64d  gcc-linaro-aarch64-linux-gnu-4.9-2014.09_linux.tar.xz
+d7805745171f63c2556083e20abbd8eb  gcc-linaro-arm-linux-gnueabihf-4.9-2014.09_linux.tar.xz

--- a/include/toolchain-func.sh
+++ b/include/toolchain-func.sh
@@ -1,30 +1,38 @@
 #!/bin/bash
 
 ###################################################################################
-# get_toolchain <toolchainsum_source_file>
+# get_toolchain <arch> <toolchainsum_source_file>
 ###################################################################################
 get_toolchain()
 {
 	(
-	toolchainsum_source_file=$1
-	cat $toolchainsum_source_file 2>/dev/null | awk '{print $2}' | sed 's/.*\///'
+	arch=$1
+	toolchainsum_source_file=$2
+	cat $toolchainsum_source_file 2>/dev/null | grep $arch | awk '{print $2}' | sed 's/.*\///'
 	)
 }
 
 ###################################################################################
 # download_toolchains <target_dir> <toolchainsum_source_file> <toolchain_source>
 ###################################################################################
-download_toolchain()
+download_toolchains()
 {
 	(
 	target_dir=$(cd $1; pwd)
 	toolchainsum_source_file=$2
 	toolchain_source=$3
-	toolchain=`cat $toolchainsum_source_file 2>/dev/null | awk '{print $2}'`
+	
+	checksum_file=`basename $toolchainsum_source_file`
+	checksum_dir=`dirname $toolchainsum_source_file`
+	checksum_dir=`cd $checksum_dir; pwd`
 
-	if ! check_sum $target_dir $toolchainsum_source_file >/dev/null 2>&1; then
+	if ! check_sum $target_dir $checksum_dir/$checksum_file >/dev/null 2>&1; then
 		pushd $target_dir >/dev/null
-		wget $toolchain_source/$toolchain || return 1
+		toolchain_files=(`md5sum --quiet --check $checksum_dir/$checksum_file 2>/dev/null | grep "FAILED" | cut -d : -f 1`)
+		for toolchain_file in ${toolchain_files[*]}; do
+			rm -f $toolchain_file 2>/dev/null
+			wget -c $toolchain_source/$toolchain_file || return 1
+		done
 		popd >/dev/null
 	fi
 
@@ -42,7 +50,7 @@ copy_toolchain()
 	src_dir=$2
 	target_dir=$3
 	if ! (diff $src_dir/.toolchain.sum $target_dir/.toolchain.sum >/dev/null 2>&1) \
-		|| [ !- f $target_dir/$toolchain ]; then
+		|| [ ! -f $target_dir/$toolchain ]; then
 		rm -f $target_dir/$toolchain 2>/dev/null
 		cp $src_dir/$toolchain $target_dir/$toolchain || return 1
 		rm -f $target_dir/.toolchain.sum 2>/dev/null
@@ -53,4 +61,26 @@ copy_toolchain()
 	)
 }
 
+###################################################################################
+# uncompress_toolchains <toolchainsum_source_file> <src_dir>
+###################################################################################
+uncompress_toolchains()
+{
+	(
+	toolchainsum_source_file=$1
+	src_dir=$2
+
+	toolchain_files=(`cat $toolchainsum_source_file 2>/dev/null | awk '{print $2}' | sed 's/.*\///'`)
+	for toolchain_file in ${toolchain_files[*]}; do
+		toolchain_dir=`get_compress_file_prefix $toolchain_file`
+		if [ ! -d $src_dir/$toolchain_dir ]; then
+			if ! uncompress_file $src_dir/$toolchain_file $src_dir; then
+				rm -rf $src_dir/$toolchain_dir 2>/dev/null ; return 1
+			fi
+		fi
+	done
+
+	return 0
+	)
+}
 


### PR DESCRIPTION
1. Add arm32 toolchain for uefi needed by hikey.

Signed-off-by: cailianchun armstar@sina.com
