### PR TITLE
Fix qemu build error when switch building between docker and host

### DIFF
--- a/submodules/build-platform.sh
+++ b/submodules/build-platform.sh
@@ -84,6 +84,9 @@ if [ x"$CLEAN" = x"yes" ]; then
 		build-uefi.sh clean --platform=$plat --output=$OUTPUT
 		build-grub.sh clean --output=$OUTPUT
 		build-kernel.sh clean --platform=$plat --cross=$CROSS_COMPILE --output=$OUTPUT
+		if [ x"$plat" = x"QEMU" ]; then
+			build-qemu.sh clean --output=$OUTPUT --distros=$DISTROS
+		fi
 	done
 
 	# clean distros

--- a/submodules/build-qemu.sh
+++ b/submodules/build-qemu.sh
@@ -76,11 +76,16 @@ KERNEL_BIN=$OUTPUT_DIR/binary/arm64/Image
 # clean qemu img
 ###################################################################################
 if [ x"$CLEAN" = x"yes" ]; then
+	echo "Clean qemu ..."
 	distros=(`echo $DISTROS | tr ',' ' '`)
 	for distro in ${distros[*]}; do
 		rm -f $DISTRO_DIR/${distro}_ARM64.img 2>/dev/null
 	done
 	
+	pushd qemu/ >/dev/null
+	make clean
+	popd >/dev/null
+
 	exit 0
 fi
 


### PR DESCRIPTION
Fix the qemu building error:
When switch building between docker and host, it will cause bellow error.

make[1]: **\* No rule to make target
`/home/chenshuangsheng/open-estuary_master/qemu/exec.c', needed by
`exec.o'. Stop.
make: **\* [subdir-aarch64-softmmu] Error 2

Signed-off-by: Xinliang Liu xinliang.liu@linaro.org
