### PR TITLE
Improve estuary scripts and fix bugs.

### DIFF
--- a/deploy/mkisoimg.sh
+++ b/deploy/mkisoimg.sh
@@ -18,7 +18,7 @@ DISK_LABEL="Estuary"
 BOOT_PARTITION_SIZE=200
 WORKSPACE=
 
-D02_CMDLINE="rdinit=/init crashkernel=256M@32M console=ttyS0,115200 earlycon=uart8250,mmio32,0x80300000 pcie_aspm=off"
+D02_CMDLINE="rdinit=/init crashkernel=256M@32M console=ttyS0,115200 earlycon=uart8250,mmio32,0x80300000 pcie_aspm=off acpi=force"
 D03_CMDLINE="rdinit=/init console=ttyS0,115200 earlycon=hisilpcuart,mmio,0xa01b0000,0,0x2f8 pcie_aspm=off acpi=force"
 D05_CMDLINE="rdinit=/init console=ttyAMA0,115200 earlycon=pl011,mmio,0x602B0000 pcie_aspm=off crashkernel=256M@32M acpi=force"
 HiKey_CMDLINE="rdinit=/init console=tty0 console=ttyAMA3,115200 rootwait rw loglevel=8 efi=noruntime"

--- a/deploy/mkpxe.sh
+++ b/deploy/mkpxe.sh
@@ -23,7 +23,7 @@ NFS_ROOT=
 NETCARD_NAME=
 SERVER_IP=
 
-D02_CMDLINE="rdinit=/init crashkernel=256M@32M console=ttyS0,115200 earlycon=uart8250,mmio32,0x80300000 pcie_aspm=off"
+D02_CMDLINE="rdinit=/init crashkernel=256M@32M console=ttyS0,115200 earlycon=uart8250,mmio32,0x80300000 pcie_aspm=off acpi=force"
 D03_CMDLINE="rdinit=/init console=ttyS0,115200 earlycon=hisilpcuart,mmio,0xa01b0000,0,0x2f8 pcie_aspm=off acpi=force"
 D05_CMDLINE="rdinit=/init console=ttyAMA0,115200 earlycon=pl011,mmio,0x602B0000 pcie_aspm=off crashkernel=256M@32M acpi=force"
 HiKey_CMDLINE="rdinit=/init console=tty0 console=ttyAMA3,115200 rootwait rw loglevel=8 efi=noruntime"

--- a/deploy/mkusbinstall.sh
+++ b/deploy/mkusbinstall.sh
@@ -20,7 +20,7 @@ DISK_LABEL="Estuary"
 BOOT_PARTITION_SIZE=4
 WORKSPACE=
 
-D02_CMDLINE="rdinit=/init crashkernel=256M@32M console=ttyS0,115200 earlycon=uart8250,mmio32,0x80300000 pcie_aspm=off"
+D02_CMDLINE="rdinit=/init crashkernel=256M@32M console=ttyS0,115200 earlycon=uart8250,mmio32,0x80300000 pcie_aspm=off acpi=force"
 D03_CMDLINE="rdinit=/init console=ttyS0,115200 earlycon=hisilpcuart,mmio,0xa01b0000,0,0x2f8 pcie_aspm=off acpi=force"
 D05_CMDLINE="rdinit=/init console=ttyAMA0,115200 earlycon=pl011,mmio,0x602B0000 pcie_aspm=off crashkernel=256M@32M acpi=force"
 HiKey_CMDLINE="rdinit=/init console=tty0 console=ttyAMA3,115200 rootwait rw loglevel=8 efi=noruntime"

--- a/deploy/setup-pxe.sh
+++ b/deploy/setup-pxe.sh
@@ -40,6 +40,23 @@ EOF
 }
 
 ###################################################################################
+# string calculate_subnet(string host_ip, string netmask)
+###################################################################################
+calculate_subnet() {
+	(
+	host_ip=$1
+	netmask=$2
+	ip_addr=(`echo $host_ip | sed 's/\./ /g'`)
+	netmasks=(`echo $netmask | sed 's/\./ /g'`)
+	subnet=()
+	for ((index=0; index<4; index++)); do
+		subnet[$index]=$[${ip_addr[index]}&${netmasks[index]}]
+	done
+	echo ${subnet[*]} | tr ' ' '.'
+	)
+}
+
+###################################################################################
 # Check host
 ###################################################################################
 host=`lsb_release -a 2>/dev/null | grep Codename: | awk {'print $2'}`
@@ -98,7 +115,7 @@ HWADDR=`ifconfig $NETCARD_NAME 2>/dev/null | grep -Po "(?<=HWaddr )([^ ]*)"`
 INET_ADDR=`ifconfig $NETCARD_NAME 2>/dev/null | grep -Po "(?<=inet addr:)([^ ]*)"`
 BROAD_CAST=`ifconfig $NETCARD_NAME 2>/dev/null | grep -Po "(?<=Bcast:)([^ ]*)"`
 INET_MASK=`ifconfig $NETCARD_NAME 2>/dev/null | grep -Po "(?<=Mask:)([^ ]*)"`
-SUB_NET=`route | grep "$NETCARD_NAME" | grep -v default | awk '{print $1}'`
+SUB_NET=`calculate_subnet $INET_ADDR $INET_MASK`
 ROUTER=`route | grep "$NETCARD_NAME" | grep default | awk '{print $2}'`
 if [ x"$ROUTER" = x"" ]; then
 	ROUTER=$INET_ADDR

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -6,9 +6,9 @@ trap 'exit 0' INT
 set +m
 echo 0 > /proc/sys/kernel/printk
 
-D02_CMDLINE="rdinit=/init crashkernel=256M@32M console=ttyS0,115200 earlycon=uart8250,mmio32,0x80300000 pcie_aspm=off ip=dhcp"
-D03_CMDLINE="rdinit=/init console=ttyS0,115200 earlycon=hisilpcuart,mmio,0xa01b0000,0,0x2f8 pcie_aspm=off ip=dhcp"
-D05_CMDLINE="rdinit=/init console=ttyAMA0,115200 earlycon=pl011,mmio,0x602B0000 pcie_aspm=off crashkernel=256M@32M acpi=force ip=dhcp"
+D02_CMDLINE="rdinit=/init crashkernel=256M@32M console=ttyS0,115200 earlycon=uart8250,mmio32,0x80300000 pcie_aspm=off acpi=force"
+D03_CMDLINE="rdinit=/init console=ttyS0,115200 earlycon=hisilpcuart,mmio,0xa01b0000,0,0x2f8 pcie_aspm=off acpi=force"
+D05_CMDLINE="rdinit=/init console=ttyAMA0,115200 earlycon=pl011,mmio,0x602B0000 pcie_aspm=off crashkernel=256M@32M acpi=force"
 HiKey_CMDLINE="rdinit=/init console=tty0 console=ttyAMA3,115200 rootwait rw loglevel=8 efi=noruntime"
 
 ###################################################################################

--- a/submodules/build-uefi.sh
+++ b/submodules/build-uefi.sh
@@ -99,6 +99,9 @@ build_uefi_for_all()
 	fi
 	mkdir -p $output_dir/binary/$platform/
 	cp $uefi_bin $output_dir/binary/$platform/UEFI_${platform}.fd
+
+	# roll back submodule
+	git submodule deinit -f .
 	popd
 	)
 }


### PR DESCRIPTION
1. Use apci boot mode for all deployments. Remove dhcp args for kernel;
2. Fix pxe bugs(calculate subnet using ip address and netmask);
3. Add deinit for UEFI building.

Signed-off-by: cailianchun armstar@sina.com
