### PR TITLE
Improve qemu build scripts.

### DIFF
--- a/submodules/build-qemu.sh
+++ b/submodules/build-qemu.sh
@@ -97,7 +97,13 @@ qemu_dir=`cd $QEMU_DIR ; pwd`
 if [ ! -f $qemu_dir/bin/qemu-system-aarch64 ] || ! update_module_check qemu $OUTPUT_DIR; then
 	pushd qemu/ >/dev/null
 	[ -d $qemu_dir ] && rm -rf $qemu_dir
-	if ! (./configure --prefix=$qemu_dir --target-list=aarch64-softmmu && make -j${CORE_NUM} && make install); then
+	if [ "`uname -m`" = "aarch64" ]; then
+		./configure --prefix=$qemu_dir --target-list=aarch64-softmmu --enable-kvm || exit 1
+	else
+		./configure --prefix=$qemu_dir --target-list=aarch64-softmmu || exit 1
+	fi
+
+	if ! (make -j${CORE_NUM} && make install); then
 		exit 1
 	fi
 	popd >/dev/null
@@ -164,6 +170,7 @@ ROOTFS=$DISTRO_DIR/${distro}_ARM64.img
 # start and run qemu
 ###################################################################################
 qemu-system-aarch64 -machine virt -cpu cortex-a57 \
+	-m 2048 \
 	-kernel $KERNEL_BIN \
 	-drive if=none,file=$ROOTFS,id=fs \
 	-device virtio-blk-device,drive=fs \


### PR DESCRIPTION
1. Enable kvm on aarch64;
2. Specify memory for qemu to avoid insufficient memory.

Signed-off-by: cailianchun <armstar@sina.com>