### PR TITLE
Change OpenStack_Manual.md path

### DIFF
--- a/doc/Packages_Manual.md
+++ b/doc/Packages_Manual.md
@@ -19,4 +19,4 @@ Currently the following packages are supported on ARM64 platforms:
     - [MongoDB](https://github.com/open-estuary/packages/blob/master/docker_apps/mongodb/MongoDB_Manual.md)
     - [LAMP](https://github.com/open-estuary/packages/blob/master/docker_apps/lamp/LAMP_Manual.md)
     - [Cassandra](https://github.com/open-estuary/packages/blob/master/docker_apps/cassandra/Cassandra_Manual.md)
-- [OpenStack](https://github.com/open-estuary/packages/blob/master/openstack/OpenStack_Manual.md)
+    - [OpenStack](https://github.com/open-estuary/packages/blob/master/openstack/doc/OpenStack_Manual.md)


### PR DESCRIPTION
change OpenStack_Manual.md path to
https://github.com/open-estuary/packages/blob/master/openstack/doc/OpenStack_Manual.md

Signed-off-by: Xinliang Liu <xinliang.liu@linaro.org>